### PR TITLE
Display board with SFML

### DIFF
--- a/Interfacee/BoardView.cpp
+++ b/Interfacee/BoardView.cpp
@@ -1,0 +1,85 @@
+#include "BoardView.h"
+
+BoardView::BoardView() {}
+
+bool BoardView::loadResources() {
+    return font.loadFromFile("files/Minecraft.ttf");
+}
+
+void BoardView::draw(sf::RenderWindow& window,
+                     const Tablero& tablero,
+                     const Jugador& jugadorActual,
+                     const Carta* cartaCentro) const {
+    const int cellSize = 100;
+    const int offsetX = 50;
+    const int offsetY = 50;
+
+    // Dibujar tablero de 5x5
+    for (int i = 0; i < Tablero::Filas; ++i) {
+        for (int j = 0; j < Tablero::Columnas; ++j) {
+            sf::RectangleShape cell(sf::Vector2f(cellSize - 2, cellSize - 2));
+            cell.setPosition(offsetX + j * cellSize, offsetY + i * cellSize);
+            cell.setFillColor(((i + j) % 2 == 0) ? sf::Color(238, 238, 210)
+                                                : sf::Color(118, 150, 86));
+            window.draw(cell);
+
+            Ficha* ficha = tablero.getPosicionFicha(i, j);
+            if (ficha) {
+                sf::CircleShape piece(cellSize / 2 - 10);
+                piece.setPosition(offsetX + j * cellSize + 10,
+                                   offsetY + i * cellSize + 10);
+                piece.setFillColor(
+                    ficha->getDueno() == 'r' ? sf::Color::Red : sf::Color::Blue);
+                window.draw(piece);
+
+                sf::Text letter;
+                letter.setFont(font);
+                letter.setString(std::string(1, ficha->getTipo()));
+                letter.setCharacterSize(20);
+                letter.setFillColor(sf::Color::White);
+                letter.setPosition(offsetX + j * cellSize + cellSize / 2 - 8,
+                                    offsetY + i * cellSize + cellSize / 2 - 12);
+                window.draw(letter);
+            }
+        }
+    }
+
+    // Dibujar cartas del jugador actual
+    for (int i = 0; i < 2; ++i) {
+        sf::RectangleShape card(sf::Vector2f(120, 80));
+        card.setPosition(offsetX + i * 140, offsetY + 5 * cellSize + 10);
+        card.setFillColor(sf::Color(240, 240, 240));
+        card.setOutlineThickness(2);
+        card.setOutlineColor(sf::Color::Black);
+        window.draw(card);
+
+        sf::Text name;
+        name.setFont(font);
+        name.setCharacterSize(16);
+        name.setFillColor(sf::Color::Black);
+        name.setString(jugadorActual.cartas[i]->getNombre());
+        name.setPosition(card.getPosition().x + 10, card.getPosition().y + 30);
+        window.draw(name);
+    }
+
+    // Texto del turno
+    sf::Text turno;
+    turno.setFont(font);
+    turno.setCharacterSize(20);
+    turno.setFillColor(sf::Color::White);
+    turno.setString(jugadorActual.getColor() == 'r' ? "Turno: Rojo"
+                                                    : "Turno: Azul");
+    turno.setPosition(offsetX + 300, offsetY + 5 * cellSize + 20);
+    window.draw(turno);
+
+    // Carta en uso/centro
+    if (cartaCentro) {
+        sf::Text centro;
+        centro.setFont(font);
+        centro.setCharacterSize(16);
+        centro.setFillColor(sf::Color::Yellow);
+        centro.setString("Carta centro: " + cartaCentro->getNombre());
+        centro.setPosition(offsetX + 300, offsetY + 5 * cellSize + 50);
+        window.draw(centro);
+    }
+}

--- a/Interfacee/BoardView.h
+++ b/Interfacee/BoardView.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include "../src/Tablero.h"
+#include "../src/Jugador.h"
+
+class BoardView {
+public:
+    BoardView();
+    bool loadResources();
+    void draw(sf::RenderWindow& window,
+              const Tablero& tablero,
+              const Jugador& jugadorActual,
+              const Carta* cartaCentro) const;
+private:
+    sf::Font font;
+};

--- a/Interfacee/sfml.cpp
+++ b/Interfacee/sfml.cpp
@@ -1,6 +1,16 @@
 #include <SFML/Graphics.hpp>
 #include "mainMenu.h"
-using namespace sf; 
+#include "BoardView.h"
+#include "../src/CartaLeon.h"
+#include "../src/CartaFenix.h"
+#include "../src/CartaTigre.h"
+#include "../src/CartaOso.h"
+#include "../src/CartaDragon.h"
+#include "../src/Rey.h"
+#include "../src/Peon.h"
+#include "../src/Tablero.h"
+#include "../src/Jugador.h"
+using namespace sf;
 
 int main() {
     // Creamos la ventana principal
@@ -41,28 +51,57 @@ int main() {
                 }
                 
                 if (event.key.code == Keyboard::Return) {
-                    RenderWindow Play(VideoMode(960, 720), "game_video");
+                    RenderWindow Play(VideoMode(960, 720), "Tablero", Style::Default);
                     RenderWindow OPTIONS(VideoMode(960, 720), "OPTIONS");
                     
                     int x = mainMenu.MainMenuPressed();
                     if (x == 0) {  // Jugar
+                        // Inicializar tablero y jugadores
+                        Tablero tablero;
+                        Jugador jugadorAzul('a');
+                        Jugador jugadorRojo('r');
+
+                        jugadorAzul.cartas[0] = new CartaLeon();
+                        jugadorAzul.cartas[1] = new CartaFenix();
+
+                        jugadorRojo.cartas[0] = new CartaTigre();
+                        jugadorRojo.cartas[1] = new CartaOso();
+
+                        Carta* cartaCentro = new CartaDragon();
+
+                        tablero.colocarFicha(new Rey('a'), 0, 2);
+                        tablero.colocarFicha(new Rey('r'), 4, 2);
+                        tablero.colocarFicha(new Peon('a'), 0, 1);
+                        tablero.colocarFicha(new Peon('a'), 0, 3);
+                        tablero.colocarFicha(new Peon('r'), 4, 1);
+                        tablero.colocarFicha(new Peon('r'), 4, 3);
+
+                        bool turnoRojo = true;
+
+                        BoardView view;
+                        view.loadResources();
+
                         while (Play.isOpen()) {
-                            Event aevent; 
+                            Event aevent;
                             while (Play.pollEvent(aevent)) {
                                 if (aevent.type == Event::Closed) {
                                     Play.close();
                                 }
-                                if (aevent.type == Event::KeyPressed) {
-                                    if (aevent.key.code == Keyboard::Escape) {
-                                        Play.close();
-                                    }
+                                if (aevent.type == Event::KeyPressed && aevent.key.code == Keyboard::Escape) {
+                                    Play.close();
+                                }
+                                if (aevent.type == Event::KeyPressed && aevent.key.code == Keyboard::Space) {
+                                    turnoRojo = !turnoRojo; // alternar turno para demostracion
                                 }
                             }
 
-                            OPTIONS.close();
+                            const Jugador& jugadorActual = turnoRojo ? jugadorRojo : jugadorAzul;
+
                             Play.clear();
+                            view.draw(Play, tablero, jugadorActual, cartaCentro);
                             Play.display();
                         }
+                        delete cartaCentro;
                     }
                     if (x == 1) {  // Opciones
                         while (OPTIONS.isOpen()) {

--- a/src/Carta.h
+++ b/src/Carta.h
@@ -1,6 +1,8 @@
 #pragma once
 
-struct Movimiento{  //para crear mov como otra clase para tener mas mov posilble en 1 carta 
+#include <string>
+
+struct Movimiento{  //para crear mov como otra clase para tener mas mov posilble en 1 carta
     int dx;
     int dy;         // le damos un dato como (x,y)
 };
@@ -13,12 +15,16 @@ protected:  // protected porque solo vamos a crear la carta no cambiar atributos
 public:
     Carta();
 
-    
+    virtual ~Carta() = default;
 
-    int getCantidadMovimientos()const; // movimientos posibles de la carta max 4 por carta 
+
+
+    int getCantidadMovimientos()const; // movimientos posibles de la carta max 4 por carta
     Movimiento getMovimiento(int index)const; // cual movimiento de los posibles se eligio
-                                              // devuelve un dato tipo movimiento osea (int x,int y) sirve al momento de querer mover la ficha 
-    void mostrarMovimientos()const; // un for que imprime los posibles movimientos de la carta 
+                                              // devuelve un dato tipo movimiento osea (int x,int y) sirve al momento de querer mover la ficha
+    void mostrarMovimientos()const; // un for que imprime los posibles movimientos de la carta
+
+    virtual std::string getNombre() const { return "Carta"; }
 
 
 };

--- a/src/CartaDragon.h
+++ b/src/CartaDragon.h
@@ -6,4 +6,6 @@ class CartaDragon : public Carta{
 public:
     CartaDragon();
 
+    std::string getNombre() const override { return "Dragon"; }
+
 };

--- a/src/CartaFenix.h
+++ b/src/CartaFenix.h
@@ -6,4 +6,6 @@ class CartaFenix : public Carta{
 public:
     CartaFenix();
 
+    std::string getNombre() const override { return "Fenix"; }
+
 };

--- a/src/CartaLeon.h
+++ b/src/CartaLeon.h
@@ -6,4 +6,6 @@ class CartaLeon : public Carta{
 public:
     CartaLeon();
 
+    std::string getNombre() const override { return "Leon"; }
+
 };

--- a/src/CartaOso.h
+++ b/src/CartaOso.h
@@ -6,4 +6,6 @@ class CartaOso : public Carta{
 public:
     CartaOso();
 
+    std::string getNombre() const override { return "Oso"; }
+
 };

--- a/src/CartaTigre.h
+++ b/src/CartaTigre.h
@@ -8,4 +8,6 @@ class CartaTigre : public Carta{
 public:
     CartaTigre();
 
+    std::string getNombre() const override { return "Tigre"; }
+
 };


### PR DESCRIPTION
## Summary
- allow each card to expose a name with `getNombre`
- add a BoardView helper to draw a 5x5 board and cards
- show a demo board when selecting **Jugar** in the menu

## Testing
- `g++ Interfacee/sfml.cpp Interfacee/BoardView.cpp src/*.cpp -I./src -I./Interfacee -lsfml-graphics -lsfml-window -lsfml-system -o juego` *(fails: `SFML/Graphics.hpp` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f680026e88333a217314787ad8894